### PR TITLE
Add Open Graph and Twitter Card meta tags

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Rich Pauloo
-description: "Thinker, tea drinker, tinkerer. Water, data, code."
+description: "Thinker, tea drinker, tinkerer."
 ---

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,7 +2,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
-  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
+  {{- $desc := .Description | default .Site.Params.description -}}
+  <meta name="description" content="{{ $desc }}">
+  <meta property="og:title" content="{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ .Site.Title }}">
+  <meta property="og:description" content="{{ $desc }}">
+  <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
+  <meta property="og:url" content="{{ .Permalink }}">
+  {{ with .Site.Params.sharing_image }}<meta property="og:image" content="{{ . | absURL }}">{{ end }}
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ .Site.Title }}">
+  <meta name="twitter:description" content="{{ $desc }}">
+  {{ with .Site.Params.sharing_image }}<meta name="twitter:image" content="{{ . | absURL }}">{{ end }}
   {{ with .Site.Params.favicon }}<link rel="icon" href="{{ . | absURL }}">{{ end }}
   <link rel="stylesheet" href="{{ "css/site.css" | absURL }}">
 </head>


### PR DESCRIPTION
## Summary
- Adds `og:title`, `og:description`, `og:type`, `og:url`, `og:image` meta tags
- Adds Twitter Card meta tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`)
- Social platforms (WhatsApp, Slack, Twitter, etc.) now show "Thinker, tea drinker, tinkerer." instead of scraping random page content

## Test plan
- [ ] Verify Netlify deploy preview builds
- [ ] Check `<head>` in page source for correct og/twitter tags
- [ ] Test sharing the deploy preview URL on a social platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)