### PR TITLE
Fix OG meta tags: use absolute URLs for social sharing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://www.richpauloo.com/"
 languageCode = "en"
 title = "Rich Pauloo"
 author = "Rich Pauloo"


### PR DESCRIPTION
## Summary
- Sets `baseURL` to `https://www.richpauloo.com/` so Hugo's `absURL` produces full URLs
- Fixes `og:url` (was `/`, now `https://www.richpauloo.com/`)
- Fixes `og:image` (was `/img/avatar.jpeg`, now `https://www.richpauloo.com/img/avatar.jpeg`)
- Social crawlers (WhatsApp, Twitter, iMessage, Slack) need absolute URLs to resolve these tags

## Test plan
- [ ] Check deploy preview page source for correct absolute URLs in OG tags
- [ ] Validate with https://opengraph.xyz using deploy preview URL
- [ ] After merging, use platform-specific cache purge tools (Twitter Card Validator, Facebook Sharing Debugger) to refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)